### PR TITLE
Change xtend.version in POM files

### DIFF
--- a/my.javafx.application/pom.xml
+++ b/my.javafx.application/pom.xml
@@ -22,7 +22,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtend.version>2.4.2-SNAPSHOT</xtend.version>
+		<xtend.version>2.4.2</xtend.version>
 	</properties>
 
 	<build>

--- a/xtendfx.tests/pom.xml
+++ b/xtendfx.tests/pom.xml
@@ -23,7 +23,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtend.version>2.4.2-SNAPSHOT</xtend.version>
+		<xtend.version>2.4.2</xtend.version>
 	</properties>
 
 	<build>
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.standalone</artifactId>
-			<version>2.4.0-SNAPSHOT</version>
+			<version>${xtend.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>xtendfx</groupId>

--- a/xtendfx/pom.xml
+++ b/xtendfx/pom.xml
@@ -23,7 +23,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtend.version>2.4.2-SNAPSHOT</xtend.version>
+		<xtend.version>2.4.2</xtend.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
I have tried to run the XtendFx build “mvn clean install” on a computer with an empty Maven repository. 

In my opinion the xtend version, defined in the properties, need to be changed:
     <xtend.version>2.4.2-SNAPSHOT</xtend.version>

It should be “2.4.2” without SNAPSHOT, because the SNAPSHOT is not available if you don’t have built xtend locally.

The ${xtend.version} should also be used for the artifactId: org.eclipse.xtend.standalone
