### PR TITLE
javafx is included in latest java7 and java8

### DIFF
--- a/xtendfx/pom.xml
+++ b/xtendfx/pom.xml
@@ -88,9 +88,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-		  <groupId>com.oracle</groupId>
-		  <artifactId>javafx</artifactId>
-		  <version>2.2.21</version>
+			<groupId>localhost</groupId>
+			<artifactId>javafx</artifactId>
+			<version>1.0</version>
+			<scope>system</scope>
+			<systemPath>${java.home}/lib/jfxrt.jar</systemPath>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Without this change, when I mvn package it does not build. Since javafx is now shipped with the jdk7 and jdk8, using the local dependency works fine.
