### PR TITLE
Update pom.xml

### DIFF
--- a/xtendfx.tests/pom.xml
+++ b/xtendfx.tests/pom.xml
@@ -7,23 +7,9 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>XtendFX-Tests</name>
 
-	<repositories>
-		<repository>
-			<id>xtend</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>xtend</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</pluginRepository>
-	</pluginRepositories>
-
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtend.version>2.5.1-SNAPSHOT</xtend.version>
+		<xtend.version>2.7.3</xtend.version>
 	</properties>
 
 	<build>
@@ -37,6 +23,7 @@
 					<execution>
 						<goals>
 							<goal>compile</goal>
+							<goal>testCompile</goal>
 							<goal>xtend-install-debug-info</goal>
 						</goals>
 					</execution>
@@ -49,8 +36,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/xtendfx/pom.xml
+++ b/xtendfx/pom.xml
@@ -7,23 +7,9 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>XtendFX</name>
 
-	<repositories>
-		<repository>
-			<id>xtend</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>xtend</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</pluginRepository>
-	</pluginRepositories>
-
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtend.version>2.5.1-SNAPSHOT</xtend.version>
+		<xtend.version>2.7.3</xtend.version>
 	</properties>
 
 	<build>
@@ -37,6 +23,7 @@
 					<execution>
 						<goals>
 							<goal>compile</goal>
+							<goal>testCompile</goal>
 							<goal>xtend-install-debug-info</goal>
 						</goals>
 					</execution>
@@ -50,8 +37,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Current pom.xml points to xtend version 2.5.1-SNAPSHOT, which does not exist anymore and (because) is way outdated.
If I am the first one to see missing artifacts in eclipse... Does this mean that nobody has opened this project in the last year? This is very sad.

I've done some changes just to get rid of errors in eclipse:
1. Remove sonatype repo. ( Current xtend is available in maven central. Do we really need to depend on snapshots? )
2. Update xtend version to 2.7.3
3. Add testCompile goal. ( I don't know what is it, but I copied it from xtend-lang.org. Is <goal>xtend-install-debug-info</goal> still relevant? )
4. Update java to 1.8 ( Why not? :-)

I don't use maven, so I don't mind if it stays like it is, but I do believe that the whole maven configuration must be reviewed and updated by somebody who actually knows and uses it. May be you can raise an issue or something?

P.S. I didn't touch pom.xml in my.javafx.application sub-project. It should be fixed too.