### PR TITLE
Make the user import the correct extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ resumeButton.disableProperty -> (anim.statusProperty != PAUSED)
 stopButton.disableProperty   -> (anim.statusProperty == STOPPED)
 ```
 
+this only needs the correct ```static extension```:
+
+```xtend
+import static extension xtendfx.beans.binding.BindingExtensions.*
+```
+
 More Examples
 =============
 


### PR DESCRIPTION
I tried the binding on a javafx project with xtend and did not get the correct behavior, but also did not receive an error from the xtend, nor the java compiler. After some puzzling, I found that a static import was needed.
Updating the documentation so that this won't happen again.